### PR TITLE
osgi-support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ buildNumber.properties
 *.iml
 .idea
 !.idea/codeStyles
+.classpath
+.project
+.settings/

--- a/pom.xml
+++ b/pom.xml
@@ -323,6 +323,33 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>manifest</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+            <exportScr>true</exportScr>
+            <instructions>
+              <_include>-bnd.bnd</_include>
+            </instructions>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+          </archive>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
We are using your library in the plc4x project. As we are currently OSGi enabling the project we also look into having OSGi bundles for all dependencies.

This PR adds two maven plugins to your pom to create the jar as a proper OSGi bundle. The difference is only in the Manifest of the jar. So this should not affect other usages.

